### PR TITLE
Minor fix for minor issue with Bandits.

### DIFF
--- a/mods/M_Agent_Bandits-master/closeBandits.json
+++ b/mods/M_Agent_Bandits-master/closeBandits.json
@@ -325,5 +325,26 @@
     
     "placate_triggers":["PLAYER_WEAK", "SOUND", "MEAT"],
     "categories":["CLASSIC"]
+  },
+{
+    "id": "surv_levershotgun",
+    "copy-from": "shotgun_base",
+    "type": "GUN",
+    "name": "handmade lever shotgun",
+    "description": "A well designed homemade lever-action shotgun.  With a 8 round magazine, this is one of the better homemade weapons.",
+    "weight": 3934,
+    "volume": 10,
+    "price": 135000,
+    "to_hit": -1,
+    "bashing": 12,
+    "material": [ "steel", "wood" ],
+    "ranged_damage": 1,
+    "dispersion": 455,
+    "durability": 6,
+    "clip_size": 8,
+    "reload": 200,
+    "barrel_length": 4,
+    "valid_mod_locations": [ [ "accessories", 2 ], [ "stock", 1 ], [ "barrel", 1 ] ],
+    "flags": [ "RELOAD_ONE" ]
   }
 ]


### PR DESCRIPTION
Guess who finally figured out a minor error in the Bandits mod? One of the mid-range bandits was referencing a survivor lever shotgun, which was removed sometime between 0.D and 0.E. Crude fix, but I just appended it to the end of the monster file. Use it or not, as you see fit, but it does work and doesn't seem to break anything. The other option was to change the gun to something more current, but I wasn't entirely sure what was a good choice for that.