### PR TITLE
Major and minor fixes and changes in various mods

### DIFF
--- a/Kenan-BrightNights-Modpack/BL9-100%-monster-resilience-version/Locations/Anomalies.json
+++ b/Kenan-BrightNights-Modpack/BL9-100%-monster-resilience-version/Locations/Anomalies.json
@@ -3,7 +3,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -97,7 +97,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -190,7 +190,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -283,7 +283,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -376,7 +376,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -472,7 +472,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -565,7 +565,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -658,7 +658,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -751,7 +751,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -843,7 +843,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -923,7 +923,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -1006,7 +1006,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -1086,7 +1086,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -1166,7 +1166,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -1246,7 +1246,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -1326,7 +1326,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -1406,7 +1406,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -1486,7 +1486,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -1565,7 +1565,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -1664,7 +1664,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -1763,7 +1763,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -1862,7 +1862,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -1961,7 +1961,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -2063,7 +2063,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -2162,7 +2162,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -2261,7 +2261,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -2360,7 +2360,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -2458,7 +2458,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -2549,7 +2549,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -2640,7 +2640,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -2734,7 +2734,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -2825,7 +2825,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -2916,7 +2916,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -3007,7 +3007,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -3098,7 +3098,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -3189,7 +3189,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -3279,7 +3279,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3351,7 +3351,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3423,7 +3423,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3495,7 +3495,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3567,7 +3567,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3639,7 +3639,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3711,7 +3711,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3786,7 +3786,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3858,7 +3858,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3929,7 +3929,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4025,7 +4025,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4118,7 +4118,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4211,7 +4211,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4304,7 +4304,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4397,7 +4397,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4490,7 +4490,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4583,7 +4583,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4676,7 +4676,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4768,7 +4768,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -4861,7 +4861,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -4954,7 +4954,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -5047,7 +5047,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -5143,7 +5143,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -5236,7 +5236,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -5329,7 +5329,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -5422,7 +5422,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -5515,7 +5515,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -5607,7 +5607,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -5700,7 +5700,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -5793,7 +5793,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -5886,7 +5886,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -5979,7 +5979,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -6072,7 +6072,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -6165,7 +6165,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -6261,7 +6261,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -6354,7 +6354,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -6446,7 +6446,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [
@@ -6539,7 +6539,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [
@@ -6632,7 +6632,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [
@@ -6725,7 +6725,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [
@@ -6818,7 +6818,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [
@@ -6911,7 +6911,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [
@@ -7004,7 +7004,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [
@@ -7097,7 +7097,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [
@@ -7190,7 +7190,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [

--- a/Kenan-BrightNights-Modpack/BL9-140%-monster-resilience-version/Locations/Anomalies.json
+++ b/Kenan-BrightNights-Modpack/BL9-140%-monster-resilience-version/Locations/Anomalies.json
@@ -3,7 +3,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -97,7 +97,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -190,7 +190,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -283,7 +283,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -376,7 +376,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -472,7 +472,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -565,7 +565,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -658,7 +658,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -751,7 +751,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -843,7 +843,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -923,7 +923,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -1006,7 +1006,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -1086,7 +1086,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -1166,7 +1166,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -1246,7 +1246,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -1326,7 +1326,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -1406,7 +1406,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -1486,7 +1486,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -1565,7 +1565,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -1664,7 +1664,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -1763,7 +1763,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -1862,7 +1862,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -1961,7 +1961,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -2063,7 +2063,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -2162,7 +2162,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -2261,7 +2261,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -2360,7 +2360,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -2458,7 +2458,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -2549,7 +2549,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -2640,7 +2640,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -2734,7 +2734,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -2825,7 +2825,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -2916,7 +2916,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -3007,7 +3007,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -3098,7 +3098,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -3189,7 +3189,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -3279,7 +3279,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3351,7 +3351,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3423,7 +3423,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3495,7 +3495,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3567,7 +3567,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3639,7 +3639,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3711,7 +3711,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3786,7 +3786,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3858,7 +3858,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3929,7 +3929,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4025,7 +4025,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4118,7 +4118,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4211,7 +4211,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4304,7 +4304,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4397,7 +4397,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4490,7 +4490,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4583,7 +4583,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4676,7 +4676,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4768,7 +4768,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -4861,7 +4861,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -4954,7 +4954,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -5047,7 +5047,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -5143,7 +5143,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -5236,7 +5236,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -5329,7 +5329,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -5422,7 +5422,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -5515,7 +5515,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -5607,7 +5607,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -5700,7 +5700,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -5793,7 +5793,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -5886,7 +5886,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -5979,7 +5979,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -6072,7 +6072,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -6165,7 +6165,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -6261,7 +6261,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -6354,7 +6354,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -6446,7 +6446,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [
@@ -6539,7 +6539,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [
@@ -6632,7 +6632,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [
@@ -6725,7 +6725,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [
@@ -6818,7 +6818,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [
@@ -6911,7 +6911,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [
@@ -7004,7 +7004,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [
@@ -7097,7 +7097,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [
@@ -7190,7 +7190,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [

--- a/Kenan-BrightNights-Modpack/BL9-175%-monster-resilience-version/Locations/Anomalies.json
+++ b/Kenan-BrightNights-Modpack/BL9-175%-monster-resilience-version/Locations/Anomalies.json
@@ -3,7 +3,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -97,7 +97,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -190,7 +190,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -283,7 +283,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -376,7 +376,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -472,7 +472,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -565,7 +565,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -658,7 +658,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -751,7 +751,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_lab9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_corral",
       "rows": [
@@ -843,7 +843,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -923,7 +923,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -1006,7 +1006,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -1086,7 +1086,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -1166,7 +1166,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -1246,7 +1246,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -1326,7 +1326,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -1406,7 +1406,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -1486,7 +1486,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultlair9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_yellow",
       "rows": [
@@ -1565,7 +1565,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -1664,7 +1664,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -1763,7 +1763,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -1862,7 +1862,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -1961,7 +1961,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -2063,7 +2063,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -2162,7 +2162,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -2261,7 +2261,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -2360,7 +2360,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_factory9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_sandbrown",
       "rows": [
@@ -2458,7 +2458,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -2549,7 +2549,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -2640,7 +2640,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -2734,7 +2734,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -2825,7 +2825,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -2916,7 +2916,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -3007,7 +3007,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -3098,7 +3098,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -3189,7 +3189,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_cultden9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_red",
       "rows": [
@@ -3279,7 +3279,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3351,7 +3351,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3423,7 +3423,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3495,7 +3495,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3567,7 +3567,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3639,7 +3639,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3711,7 +3711,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3786,7 +3786,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3858,7 +3858,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_powerst9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_cyan",
       "rows": [
@@ -3929,7 +3929,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4025,7 +4025,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4118,7 +4118,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4211,7 +4211,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4304,7 +4304,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4397,7 +4397,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4490,7 +4490,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4583,7 +4583,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4676,7 +4676,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_argan9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_purple",
       "rows": [
@@ -4768,7 +4768,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -4861,7 +4861,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -4954,7 +4954,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -5047,7 +5047,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -5143,7 +5143,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -5236,7 +5236,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -5329,7 +5329,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -5422,7 +5422,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -5515,7 +5515,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_wanzel9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_limegreen",
       "rows": [
@@ -5607,7 +5607,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -5700,7 +5700,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -5793,7 +5793,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -5886,7 +5886,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -5979,7 +5979,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -6072,7 +6072,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -6165,7 +6165,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -6261,7 +6261,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -6354,7 +6354,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_davran9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_azureblue",
       "rows": [
@@ -6446,7 +6446,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden1" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [
@@ -6539,7 +6539,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden2" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [
@@ -6632,7 +6632,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden3" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [
@@ -6725,7 +6725,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden4" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [
@@ -6818,7 +6818,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden5" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [
@@ -6911,7 +6911,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden6" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [
@@ -7004,7 +7004,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden7" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [
@@ -7097,7 +7097,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden8" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [
@@ -7190,7 +7190,7 @@
     "type": "mapgen",
     "om_terrain": [ "BL9_anomaly_salden9" ],
     "method": "json",
-    "weight": 100,
+    "weight": 0,
     "object": {
       "fill_ter": "t_BL9uniqmazing_fl_orange",
       "rows": [

--- a/Kenan-BrightNights-Modpack/EngineeringEssentials-master/ammo.json
+++ b/Kenan-BrightNights-Modpack/EngineeringEssentials-master/ammo.json
@@ -13,6 +13,6 @@
     "material": [ "plastic", "aluminum" ],
     "dispersion": 180,
     "effects": [ "INCENDIARY", "TRAIL", "LARGE_BEANBAG", "DRAW_AS_LINE" ],
-    "relative": { "range": -30, "damage": { "damage_type": "stab", "amount": 50, "armor_penetration": -15 }, }
+    "relative": { "range": -30, "damage": { "damage_type": "stab", "amount": 50, "armor_penetration": -15 } }
   }
 ]

--- a/Kenan-BrightNights-Modpack/EngineeringEssentials-master/gunmod.json
+++ b/Kenan-BrightNights-Modpack/EngineeringEssentials-master/gunmod.json
@@ -13,7 +13,7 @@
     "symbol": ":",
     "color": "dark_gray",
     "location": "mechanism",
-    "mod_targets": [ "tihar", "helsing", "pneumatic_shotgun", "airspeargun" ],
+    "mod_targets": [ "tihar", "helsing", "pneumatic_shotgun" ],
     "install_time": "30 m",
     "min_skills": [ [ "electronics", 2 ], [ "mechanics", 3 ] ],
     "ups_charges_modifier": 5,

--- a/Kenan-BrightNights-Modpack/Fuji_Structures/worldgen/houses/_house_template.json
+++ b/Kenan-BrightNights-Modpack/Fuji_Structures/worldgen/houses/_house_template.json
@@ -2,6 +2,7 @@
   {
     "type": "mapgen",
     "method": "json",
+	"weight": 0,
     "om_terrain": [ "_house_template" ],
     "object": {
       "fill_ter": "t_floor",

--- a/Kenan-BrightNights-Modpack/Fuji_Structures/worldgen/houses/_house_template.json
+++ b/Kenan-BrightNights-Modpack/Fuji_Structures/worldgen/houses/_house_template.json
@@ -2,7 +2,7 @@
   {
     "type": "mapgen",
     "method": "json",
-	"weight": 0,
+    "weight": 0,
     "om_terrain": [ "_house_template" ],
     "object": {
       "fill_ter": "t_floor",

--- a/Kenan-BrightNights-Modpack/Modern-Weapons-Pack-Expanded/modern_handgun/modern_handgun.json
+++ b/Kenan-BrightNights-Modpack/Modern-Weapons-Pack-Expanded/modern_handgun/modern_handgun.json
@@ -74,7 +74,7 @@
     "to_hit": -2,
     "bashing": 12,
     "material": [ "steel", "wood" ],
-    "ammo": [ "44", "357mag", "45", "38" ],
+    "ammo": [ "44", "357mag", "45" ],
     "ranged_damage": { "damage_type": "stab", "amount": -1 },
     "dispersion": 200,
     "durability": 8,

--- a/Kenan-BrightNights-Modpack/PKs_Rebalancing/items/ammo.json
+++ b/Kenan-BrightNights-Modpack/PKs_Rebalancing/items/ammo.json
@@ -474,7 +474,7 @@
       "type": "explosion",
       "emp_blast_radius": 5,
       "explosion": { "power": 60, "distance_factor": 0.4, "shrapnel": 4 },
-      "fields_type": "fd_rubble",
+      "fields_type": "fd_plasma",
       "fields_radius": 2,
       "fields_min_intensity": 0,
       "fields_max_intensity": 1

--- a/Kenan-BrightNights-Modpack/PKs_Rebalancing/items/gun.json
+++ b/Kenan-BrightNights-Modpack/PKs_Rebalancing/items/gun.json
@@ -160,7 +160,7 @@
     "symbol": ":",
     "color": "i_magenta",
     "location": "underbarrel",
-    "mod_targets": [ "rifle", "crossbow", "shotgun", "launchers" ],
+    "mod_targets": [ "rifle", "crossbow", "shotgun" ],
     "gun_data": {
       "ammo": "bomblet",
       "skill": "launcher",


### PR DESCRIPTION
`BL9 worldgen locations:` since those are still unused and are part of future "secret expansion" I've changed their weight generation to zero so they don't spam into debug log every time.

`Engineering Essentials:` removed unnecessary separator in `plasma_slug` relatives; this one is critical.
Made little change for electric pump mod: removed it's acceptability for airspeargun, since this thing is for underwater use and shouldn't be used with electrical things (and it doesn't have mechanism slots anyway)

`Fuji Structures:` added zero weight generation for house template for it not to shown up in debug log.

`Modern Weapon Pack:` removed .38 ammo type from compatible ammo list for automag. This is leftover from previous Issue #6 which I will close now.

`PK's Rebalancing:` replaced BFG field type effect from `fd_rubble` to `fd_plasma` because `fd_rubble` is obsolete since https://github.com/cataclysmbnteam/Cataclysm-BN/commit/db86538991e205176afdb9bb9e8cbea2f531cfc4, and it's more fitting for the BFG!
Also removed launchers from mod targets for underbarrel bomblet launcher, because there are no slots, and you probably shouldn't attach launcher onto your launcher.