### PR TITLE
Update secro_effects.json

### DIFF
--- a/Kenan-BrightNights-Modpack/secronom/Modification Files/Monsters/-Essentials/secro_effects.json
+++ b/Kenan-BrightNights-Modpack/secronom/Modification Files/Monsters/-Essentials/secro_effects.json
@@ -1412,9 +1412,9 @@
     "//": "Used only on tamed secronom dragon, so players would be able to ride it.",
     "type": "effect_type",
     "id": "pet",
-    "max_duration": 10,
     "name": [ "Dragon" ],
-    "desc": [ "tamed secronom dragon." ]
+    "desc": [ "tamed secronom dragon." ],
+    "permanent": true
   },
   {
     "type": "effect_type",


### PR DESCRIPTION
This fixes it. The change was overriding the regular pet effect, and there doesn't appear to be a method of taming the Dragon anyway.