### PR TITLE
Update locations.json

### DIFF
--- a/Kenan-BrightNights-Modpack/Abrahms_Recipes/itemgroups/Locations_MapExtras/locations.json
+++ b/Kenan-BrightNights-Modpack/Abrahms_Recipes/itemgroups/Locations_MapExtras/locations.json
@@ -180,7 +180,6 @@
       [ "v6_combustion", 10 ],
       [ "v6_diesel", 10 ],
       [ "v8_combustion", 10 ],
-      [ "1cyl_combustion_small", 10 ],
       [ "steam_triple_small", 1 ],
       [ "steam_triple_medium", 1 ],
       [ "steam_watts_small", 1 ],


### PR DESCRIPTION
Soon, according to that
cataclysmbnteam/Cataclysm-BN#801
1cyl_combustion_small will be removed so it have to be either removed or changed into 1cyl_combustion.