### PR TITLE
Update ver_recipes.json

### DIFF
--- a/Kenan-BrightNights-Modpack/Vermilion_Mod/ver_recipes.json
+++ b/Kenan-BrightNights-Modpack/Vermilion_Mod/ver_recipes.json
@@ -1,5 +1,5 @@
-[ 
- {
+[
+  {
     "result": "reloaded_145x114mm",
     "type": "recipe",
     "category": "CC_AMMO",
@@ -12,478 +12,255 @@
     "book_learn": [ [ "recipe_bullets", 6 ] ],
     "charges": 1,
     "using": [ [ "bullet_forming", 18 ], [ "ammo_bullet", 12 ] ],
-    "components": [
-      [ [ "145x114mm_casing", 1 ] ],
-      [ [ "lgrifle_primer", 1 ] ],
-      [ [ "gunpowder", 35 ] ],
-      [ [ "copper", 8 ] ]
-    ]
+    "components": [ [ [ "145x114mm_casing", 1 ] ], [ [ "lgrifle_primer", 1 ] ], [ [ "gunpowder", 35 ] ], [ [ "copper", 8 ] ] ]
   },
-  	{
+  {
     "type": "recipe",
     "result": "s01ra_mag",
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_MAGAZINES",
     "skill_used": "fabrication",
     "difficulty": 6,
-	"skills_required": [ "gun", 5 ],
+    "skills_required": [ "gun", 5 ],
     "time": 180000,
-    "book_learn": [
-		[ "pb_leaflet_shion", 8 ] ],
+    "book_learn": [ [ "pb_leaflet_shion", 8 ] ],
     "qualities": [
-		{ "id": "CHISEL", "level": 3 },
-		{ "id": "HAMMER_FINE", "level": 1 },
-		{ "id": "SAW_M_FINE", "level": 1 },
-		{ "id": "SCREW_FINE", "level": 1 },
-		{ "id": "WRENCH_FINE", "level": 1 },
-		{ "id": "GLARE", "level": 2 },
-		{ "id": "HAMMER", "level": 2 }
-	],
-    "tools": [
-		[ [ "swage", -1 ] ],
-		[ [ "magnifying_glass", -1 ] ],
-		[ [ "press", -1] ],
-		[ [ "polisher", 10 ] ],
-		[
-			[ "soldering_iron", 30 ],
-			[ "toolset", 30 ]
-		],
-		[
-			[ "large_repairkit", 30 ],
-			[ "small_repairkit", 30 ]
-		],
-		[
-			[ "oxy_torch", 6 ],
-			[ "welder", 30 ],
-			[ "welder_crude", 60 ],
-			[ "toolset", 30 ]
-		],
-		[ [ "tongs", -1 ] ],
-		[ [ "anvil", -1 ] ],
-		[
-			[ "crucible", -1 ],
-			[ "crucible_clay", -1 ]
-		]
+      { "id": "CHISEL", "level": 3 },
+      { "id": "HAMMER_FINE", "level": 1 },
+      { "id": "SAW_M_FINE", "level": 1 },
+      { "id": "SCREW_FINE", "level": 1 },
+      { "id": "WRENCH_FINE", "level": 1 },
+      { "id": "GLARE", "level": 2 },
+      { "id": "HAMMER", "level": 2 }
     ],
-    "components": [
-		[ [ "spring", 2 ] ],
-		[ 
-			[ "steel_chunk", 24 ],
-			[ "steel_lump", 12 ]
-		]
-	]
-	},
-	{
+    "tools": [
+      [ [ "swage", -1 ] ],
+      [ [ "magnifying_glass", -1 ] ],
+      [ [ "press", -1 ] ],
+      [ [ "polisher", 10 ] ],
+      [ [ "soldering_iron", 30 ], [ "toolset", 30 ] ],
+      [ [ "large_repairkit", 30 ], [ "small_repairkit", 30 ] ],
+      [ [ "oxy_torch", 6 ], [ "welder", 30 ], [ "welder_crude", 60 ], [ "toolset", 30 ] ],
+      [ [ "tongs", -1 ] ],
+      [ [ "anvil", -1 ] ],
+      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ]
+    ],
+    "components": [ [ [ "spring", 2 ] ], [ [ "steel_chunk", 24 ], [ "steel_lump", 12 ] ] ]
+  },
+  {
     "type": "recipe",
     "result": "railaccelerator",
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_RANGED",
     "skill_used": "fabrication",
     "difficulty": 8,
-	"skills_required": [["mechanics", 10], ["electronics", 9], ["computer", 6]],
+    "skills_required": [ [ "mechanics", 10 ], [ "electronics", 9 ], [ "computer", 6 ] ],
     "time": 1330000,
-    "book_learn": [
-		[ "pb_leaflet_shion", 8 ] ],
+    "book_learn": [ [ "pb_leaflet_shion", 8 ] ],
     "qualities": [
-		{ "id": "CHISEL", "level": 3 },
-		{ "id": "SAW_M","level": 1 },
-		{ "id": "HAMMER_FINE", "level": 1 },
-		{ "id": "SAW_M_FINE", "level": 1 },
-		{ "id": "SCREW_FINE", "level": 1 },
-		{ "id": "WRENCH_FINE", "level": 1 },
-		{ "id": "GLARE", "level": 2 },
-		{ "id": "HAMMER", "level": 3 }
-	],
+      { "id": "CHISEL", "level": 3 },
+      { "id": "SAW_M", "level": 1 },
+      { "id": "HAMMER_FINE", "level": 1 },
+      { "id": "SAW_M_FINE", "level": 1 },
+      { "id": "SCREW_FINE", "level": 1 },
+      { "id": "WRENCH_FINE", "level": 1 },
+      { "id": "GLARE", "level": 2 },
+      { "id": "HAMMER", "level": 3 }
+    ],
     "tools": [
-		[ [ "swage", -1 ] ],
-		[ [ "magnifying_glass", -1 ] ],
-		[ [ "press", -1] ],
-		[ [ "polisher", 75 ] ],
-		[
-			[ "soldering_iron", 115 ],
-			[ "toolset", 115 ]
-		],
-		[
-			[ "large_repairkit", 65 ],
-			[ "small_repairkit", 130 ]
-		],
-		[
-			[ "oxy_torch", 55 ],
-			[ "welder", 200 ],
-			[ "toolset", 200 ]
-		],
-		[ [ "tongs", -1 ] ],
-		[ [ "anvil", -1 ] ],
-		[
-			[ "crucible", -1 ],
-			[ "crucible_clay", -1 ] ],
-			[
-			["mold_plastic", -1] ]
+      [ [ "swage", -1 ] ],
+      [ [ "magnifying_glass", -1 ] ],
+      [ [ "press", -1 ] ],
+      [ [ "polisher", 75 ] ],
+      [ [ "soldering_iron", 115 ], [ "toolset", 115 ] ],
+      [ [ "large_repairkit", 65 ], [ "small_repairkit", 130 ] ],
+      [ [ "oxy_torch", 55 ], [ "welder", 200 ], [ "toolset", 200 ] ],
+      [ [ "tongs", -1 ] ],
+      [ [ "anvil", -1 ] ],
+      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
+      [ [ "mold_plastic", -1 ] ]
     ],
     "components": [
-			[
-			[ "heavy_rail_rifle", 1 ] ],
-			[
-			[ "m134", 1 ],
-			[ "frame", 6 ] ],
-			[
-			[ "m107a1", 1 ],
-			[ "steel_lump", 25 ] ],
-			[
-			[ "spring", 5 ] ],
-			[ 
-			[ "steel_chunk", 15 ],
-			[ "scrap", 30 ] ],
-			[
-			[ "e_scrap", 35] ],
-			[
-			[ "alloy_plate", 1 ] ],
-			[
-			[ "ceramic_shard", 45 ] ],
-			[
-			[ "plastic_chunk", 20 ] ],
-			[
-			["amplifier", 6] ],
-			[
-			["cable", 240] ],
-			[
-			["RAM", 2] ],
-			[
-        [ "small_storage_battery", 7],
-        [ "UPS_off", 3] ]
-	  ]
-	},
-	{
-  "type" : "recipe",
-  "result": "e_rail",
-  "category": "CC_AMMO",
-  "subcategory": "CSC_AMMO_OTHER",
-  "skill_used": "fabrication",
-  "difficulty": 3,
-  "time": 140000,
-  "book_learn": [
-		[ "pb_leaflet_shion", 8 ] ],
-  "qualities":[
-    {"id":"HAMMER","level":1},
-    {"id":"SAW_M","level":1},
-	{ "id": "HAMMER_FINE", "level": 1 },
-	{ "id": "SCREW","level": 1 }
-  ], "components": [
-    [
-      ["rebar", 2]
-	  ],
-	  [
-	  ["chem_rdx", 1]
-	  ],
-	  [
-	  ["scrap", 3]
-	  ]
+      [ [ "heavy_rail_rifle", 1 ] ],
+      [ [ "m134", 1 ], [ "frame", 6 ] ],
+      [ [ "m107a1", 1 ], [ "steel_lump", 25 ] ],
+      [ [ "spring", 5 ] ],
+      [ [ "steel_chunk", 15 ], [ "scrap", 30 ] ],
+      [ [ "e_scrap", 35 ] ],
+      [ [ "alloy_plate", 1 ] ],
+      [ [ "ceramic_shard", 45 ] ],
+      [ [ "plastic_chunk", 20 ] ],
+      [ [ "amplifier", 6 ] ],
+      [ [ "cable", 240 ] ],
+      [ [ "RAM", 2 ] ],
+      [ [ "small_storage_battery", 7 ], [ "UPS_off", 3 ] ]
     ]
-},
-{
-  "type" : "recipe",
-  "result": "accelerator_battery",
-  "category": "CC_WEAPON",
-  "subcategory": "CSC_WEAPON_MODS",
-  "skill_used": "fabrication",
-  "difficulty": 8,
-  "time": 115500,
-  "book_learn": [
-		[ "pb_leaflet_shion", 8 ] ],
-  "qualities":[
-    {"id":"HAMMER","level":1},
-    {"id":"SAW_M","level":1},
-	{ "id": "HAMMER_FINE", "level": 1 },
-	{ "id": "SCREW","level": 1 },
-	{ "id": "WRENCH_FINE", "level": 1 },
-	{ "id": "GLARE", "level": 2 }
-	],
-	"tools": [
-	[
-	[ "welder", 75 ],
-	[ "welder_crude", 150 ],
-	[ "toolset", 75 ],
-	[ "oxy_torch", 65 ]
-	],
-	[
-	[ "soldering_iron", 75 ],
-	[ "toolset", 75 ]
-	],
-	[
-	[ "press", -1 ]
-	],
-	[
-	[ "magnifying_glass", -1 ]
-	],
-	[
-	[ "tongs", -1 ]
-	],
-	[
-	[ "anvil", -1 ]
-	],
-	[
-	[ "crucible", -1 ],
-	[ "crucible_clay", -1 ]
-	]
-	],
-	"components": [
-    [
-      [ "plut_cell", 10]
-	  ],
-	  [
-	  [ "can_drink", 4 ],
-	  [ "scrap", 16 ]
-	  ],
-	  [
-	  [ "scrap", 15 ]
-	  ],
-	  [
-	  [ "plastic_chunk", 10 ]
-	  ],
-	  [
-	  [ "e_scrap", 15 ]
-	  ],
-	  [
-	  [ "ceramic_shard", 4 ]
-	  ],
-	  [
-	  [ "lead", 80 ]
-	  ]
-    ]	
-},
-{
-  "type" : "recipe",
-  "result": "incendiary_battery",
-  "category": "CC_WEAPON",
-  "subcategory": "CSC_WEAPON_MODS",
-  "skill_used": "fabrication",
-  "difficulty": 8,
-  "time": 115500,
-  "book_learn": [
-		[ "pb_leaflet_shion", 8 ] ],
-  "qualities":[
-    {"id":"HAMMER","level":1},
-    {"id":"SAW_M","level":1},
-	{ "id": "HAMMER_FINE", "level": 1 },
-	{ "id": "SCREW","level": 1 },
-	{ "id": "WRENCH_FINE", "level": 1 },
-	{ "id": "GLARE", "level": 2 }
-	],
-	"tools": [
-	[
-	[ "welder", 75 ],
-	[ "welder_crude", 150 ],
-	[ "toolset", 75 ],
-	[ "oxy_torch", 65 ]
-	],
-	[
-	[ "soldering_iron", 75 ],
-	[ "toolset", 75 ]
-	],
-	[
-	[ "chemistry_set", 75 ]
-	],
-	[
-	[ "press", -1 ]
-	],
-	[
-	[ "magnifying_glass", -1 ]
-	],
-	[
-	[ "tongs", -1 ]
-	],
-	[
-	[ "anvil", -1 ]
-	],
-	[
-	[ "crucible", -1 ],
-	[ "crucible_clay", -1 ]
-	]
-	],
-	"components": [
-    [
-      [ "plut_cell", 5 ]
-	  ],
-	  [
-	  [ "incendiary", 200 ]
-	  ],
-	  [
-	  [ "can_drink", 4 ],
-	  [ "scrap", 16 ]
-	  ],
-	  [
-	  [ "scrap", 25 ]
-	  ],
-	  [
-	  [ "plastic_chunk", 20 ]
-	  ],
-	  [
-	  [ "e_scrap", 15 ]
-	  ],
-	  [
-	  [ "ceramic_shard", 12 ]
-	  ],
-	  [
-	  [ "lead", 150 ]
-	  ]
-    ]	
-},
-{
-  "type" : "recipe",
-  "result": "shock_battery",
-  "category": "CC_WEAPON",
-  "subcategory": "CSC_WEAPON_MODS",
-  "skill_used": "fabrication",
-  "difficulty": 8,
-  "time": 115500,
-  "book_learn": [
-		[ "pb_leaflet_shion", 8 ] ],
-  "qualities":[
-    {"id":"HAMMER","level":1},
-    {"id":"SAW_M","level":1},
-	{ "id": "HAMMER_FINE", "level": 1 },
-	{ "id": "SCREW","level": 1 },
-	{ "id": "WRENCH_FINE", "level": 1 },
-	{ "id": "GLARE", "level": 2 }
-	],
-	"tools": [
-	[
-	[ "welder", 75 ],
-	[ "welder_crude", 150 ],
-	[ "toolset", 75 ],
-	[ "oxy_torch", 65 ]
-	],
-	[
-	[ "soldering_iron", 75 ],
-	[ "toolset", 75 ]
-	],
-	[
-	[ "chemistry_set", 75 ]
-	],
-	[
-	[ "press", -1 ]
-	],
-	[
-	[ "magnifying_glass", -1 ]
-	],
-	[
-	[ "tongs", -1 ]
-	],
-	[
-	[ "anvil", -1 ]
-	],
-	[
-	[ "crucible", -1 ],
-	[ "crucible_clay", -1 ]
-	]
-	],
-	"components": [
-    [
-      [ "plut_cell", 5 ]
-	  ],
-	  [
-	  [ "acid", 100 ]
-	  ],
-	  [
-	  [ "magnesium", 100 ]
-	  ],
-	  [
-	  [ "can_drink", 4 ],
-	  [ "scrap", 16 ]
-	  ],
-	  [
-	  [ "scrap", 25 ]
-	  ],
-	  [
-	  [ "plastic_chunk", 20 ]
-	  ],
-	  [
-	  [ "e_scrap", 15 ]
-	  ],
-	  [
-	  [ "ceramic_shard", 12 ]
-	  ],
-	  [
-	  [ "lead", 150 ]
-	  ]
-    ]	
-},
-{
-  "type" : "recipe",
-  "result": "jet_hammer_off",
-  "category": "CC_WEAPON",
-  "subcategory": "CSC_WEAPON_BASHING",
-  "skill_used": "fabrication",
-  "difficulty": 6,
-  "time": 145500,
-  "book_learn": [
-		[ "pb_leaflet_shion", 8 ] ],
-  "qualities":[
-    {"id":"HAMMER","level":1},
-    {"id":"SAW_M","level":1},
-	{ "id": "HAMMER_FINE", "level": 1 },
-	{ "id": "SCREW","level": 1 },
-	{ "id": "WRENCH_FINE", "level": 1 },
-	{ "id": "GLARE", "level": 2 }
-	],
-	"tools": [
-	[
-	[ "welder", 150 ],
-	[ "welder_crude", 200 ],
-	[ "toolset", 150 ],
-	[ "oxy_torch", 120 ]
-	],
-	[
-	[ "soldering_iron", 90 ],
-	[ "toolset", 90 ]
-	],
-	[
-	[ "press", -1 ]
-	],
-	[
-	[ "tongs", -1 ]
-	],
-	[
-	[ "anvil", -1 ]
-	],
-	[
-	[ "crucible", -1 ],
-	[ "crucible_clay", -1 ]
-	]
-	],
-	"components": [
-	  [
-	  [ "hammer_sledge", 1 ],
-	  [ "steel_lump", 15 ]
-	  ],
-	  [
-	  [ "can_drink", 4 ],
-	  [ "thermos", 2 ],
-	  [ "scrap", 16 ]
-	  ],
-	  [
-	  [ "scrap", 75 ],
-	  [ "steel_chunk", 40 ],
-	  [ "steel_lump", 25 ]
-	  ],
-	  [
-	  [ "hose", 2 ]
-	  ],
-	  [
-	  [ "1cyl_combustion_small", 1 ]
-	  ],
-	  [
-	  [ "metal_tank_little", 1 ]
-	  ],
-	  [
-	  [ "plastic_chunk", 20 ]
-	  ],
-	  [
-	  [ "ceramic_shard", 12 ]
-	  ],
-	  [
-	  [ "lead", 200 ]
-	  ]
-    ]	
-}
-  ]
+  },
+  {
+    "type": "recipe",
+    "result": "e_rail",
+    "category": "CC_AMMO",
+    "subcategory": "CSC_AMMO_OTHER",
+    "skill_used": "fabrication",
+    "difficulty": 3,
+    "time": 140000,
+    "book_learn": [ [ "pb_leaflet_shion", 8 ] ],
+    "qualities": [
+      { "id": "HAMMER", "level": 1 },
+      { "id": "SAW_M", "level": 1 },
+      { "id": "HAMMER_FINE", "level": 1 },
+      { "id": "SCREW", "level": 1 }
+    ],
+    "components": [ [ [ "rebar", 2 ] ], [ [ "chem_rdx", 1 ] ], [ [ "scrap", 3 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "accelerator_battery",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MODS",
+    "skill_used": "fabrication",
+    "difficulty": 8,
+    "time": 115500,
+    "book_learn": [ [ "pb_leaflet_shion", 8 ] ],
+    "qualities": [
+      { "id": "HAMMER", "level": 1 },
+      { "id": "SAW_M", "level": 1 },
+      { "id": "HAMMER_FINE", "level": 1 },
+      { "id": "SCREW", "level": 1 },
+      { "id": "WRENCH_FINE", "level": 1 },
+      { "id": "GLARE", "level": 2 }
+    ],
+    "tools": [
+      [ [ "welder", 75 ], [ "welder_crude", 150 ], [ "toolset", 75 ], [ "oxy_torch", 65 ] ],
+      [ [ "soldering_iron", 75 ], [ "toolset", 75 ] ],
+      [ [ "press", -1 ] ],
+      [ [ "magnifying_glass", -1 ] ],
+      [ [ "tongs", -1 ] ],
+      [ [ "anvil", -1 ] ],
+      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ]
+    ],
+    "components": [
+      [ [ "plut_cell", 10 ] ],
+      [ [ "can_drink", 4 ], [ "scrap", 16 ] ],
+      [ [ "scrap", 15 ] ],
+      [ [ "plastic_chunk", 10 ] ],
+      [ [ "e_scrap", 15 ] ],
+      [ [ "ceramic_shard", 4 ] ],
+      [ [ "lead", 80 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "incendiary_battery",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MODS",
+    "skill_used": "fabrication",
+    "difficulty": 8,
+    "time": 115500,
+    "book_learn": [ [ "pb_leaflet_shion", 8 ] ],
+    "qualities": [
+      { "id": "HAMMER", "level": 1 },
+      { "id": "SAW_M", "level": 1 },
+      { "id": "HAMMER_FINE", "level": 1 },
+      { "id": "SCREW", "level": 1 },
+      { "id": "WRENCH_FINE", "level": 1 },
+      { "id": "GLARE", "level": 2 }
+    ],
+    "tools": [
+      [ [ "welder", 75 ], [ "welder_crude", 150 ], [ "toolset", 75 ], [ "oxy_torch", 65 ] ],
+      [ [ "soldering_iron", 75 ], [ "toolset", 75 ] ],
+      [ [ "chemistry_set", 75 ] ],
+      [ [ "press", -1 ] ],
+      [ [ "magnifying_glass", -1 ] ],
+      [ [ "tongs", -1 ] ],
+      [ [ "anvil", -1 ] ],
+      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ]
+    ],
+    "components": [
+      [ [ "plut_cell", 5 ] ],
+      [ [ "incendiary", 200 ] ],
+      [ [ "can_drink", 4 ], [ "scrap", 16 ] ],
+      [ [ "scrap", 25 ] ],
+      [ [ "plastic_chunk", 20 ] ],
+      [ [ "e_scrap", 15 ] ],
+      [ [ "ceramic_shard", 12 ] ],
+      [ [ "lead", 150 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "shock_battery",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MODS",
+    "skill_used": "fabrication",
+    "difficulty": 8,
+    "time": 115500,
+    "book_learn": [ [ "pb_leaflet_shion", 8 ] ],
+    "qualities": [
+      { "id": "HAMMER", "level": 1 },
+      { "id": "SAW_M", "level": 1 },
+      { "id": "HAMMER_FINE", "level": 1 },
+      { "id": "SCREW", "level": 1 },
+      { "id": "WRENCH_FINE", "level": 1 },
+      { "id": "GLARE", "level": 2 }
+    ],
+    "tools": [
+      [ [ "welder", 75 ], [ "welder_crude", 150 ], [ "toolset", 75 ], [ "oxy_torch", 65 ] ],
+      [ [ "soldering_iron", 75 ], [ "toolset", 75 ] ],
+      [ [ "chemistry_set", 75 ] ],
+      [ [ "press", -1 ] ],
+      [ [ "magnifying_glass", -1 ] ],
+      [ [ "tongs", -1 ] ],
+      [ [ "anvil", -1 ] ],
+      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ]
+    ],
+    "components": [
+      [ [ "plut_cell", 5 ] ],
+      [ [ "acid", 100 ] ],
+      [ [ "magnesium", 100 ] ],
+      [ [ "can_drink", 4 ], [ "scrap", 16 ] ],
+      [ [ "scrap", 25 ] ],
+      [ [ "plastic_chunk", 20 ] ],
+      [ [ "e_scrap", 15 ] ],
+      [ [ "ceramic_shard", 12 ] ],
+      [ [ "lead", 150 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "jet_hammer_off",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "skill_used": "fabrication",
+    "difficulty": 6,
+    "time": 145500,
+    "book_learn": [ [ "pb_leaflet_shion", 8 ] ],
+    "qualities": [
+      { "id": "HAMMER", "level": 1 },
+      { "id": "SAW_M", "level": 1 },
+      { "id": "HAMMER_FINE", "level": 1 },
+      { "id": "SCREW", "level": 1 },
+      { "id": "WRENCH_FINE", "level": 1 },
+      { "id": "GLARE", "level": 2 }
+    ],
+    "tools": [
+      [ [ "welder", 150 ], [ "welder_crude", 200 ], [ "toolset", 150 ], [ "oxy_torch", 120 ] ],
+      [ [ "soldering_iron", 90 ], [ "toolset", 90 ] ],
+      [ [ "press", -1 ] ],
+      [ [ "tongs", -1 ] ],
+      [ [ "anvil", -1 ] ],
+      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ]
+    ],
+    "components": [
+      [ [ "hammer_sledge", 1 ], [ "steel_lump", 15 ] ],
+      [ [ "can_drink", 4 ], [ "thermos", 2 ], [ "scrap", 16 ] ],
+      [ [ "scrap", 75 ], [ "steel_chunk", 40 ], [ "steel_lump", 25 ] ],
+      [ [ "hose", 2 ] ],
+      [ [ "1cyl_combustion", 1 ] ],
+      [ [ "metal_tank_little", 1 ] ],
+      [ [ "plastic_chunk", 20 ] ],
+      [ [ "ceramic_shard", 12 ] ],
+      [ [ "lead", 200 ] ]
+    ]
+  }
+]


### PR DESCRIPTION
Soon, according to that
cataclysmbnteam/Cataclysm-BN#801
1cyl_combustion_small will be removed so it have to be either removed or changed into 1cyl_combustion.

Also linted this shit. So the only change was deleting `_small` from `1cyl_combustion_small` in `jet_hammer_off` recipe