### PR TITLE
Martial Arts Files

### DIFF
--- a/Kenan-BrightNights-Modpack/CBMArms/martialarts.json
+++ b/Kenan-BrightNights-Modpack/CBMArms/martialarts.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "style_eskrima",
+    "copy-from": "style_eskrima",
+    "type": "martial_art",
+    "name": { "str": "Eskrima" },
+    "extend": { "weapons": [ "cbma_mono_knife" ] }
+  },
+  {
+    "id": "style_fencing",
+    "copy-from": "style_fencing",
+    "type": "martial_art",
+    "name": { "str": "Fencing" },
+    "extend": { "weapons": [ "cbma_mono_sword" ] }
+  },
+  {
+    "id": "style_krav_maga",
+    "copy-from": "style_krav_maga",
+    "type": "martial_art",
+    "name": { "str": "Krav Maga" },
+    "extend": { "weapons": [ "cbma_mono_knife" ] }
+  },
+  {
+    "id": "style_swordsmanship",
+    "copy-from": "style_swordsmanship",
+    "type": "martial_art",
+    "name": { "str": "Medieval Swordsmanship" },
+    "extend": { "weapons": [ "cbma_mono_sword" ] }
+  },
+  {
+    "id": "style_ninjutsu",
+    "copy-from": "style_ninjutsu",
+    "type": "martial_art",
+    "name": { "str": "Ninjutsu" },
+    "extend": { "weapons": [ "cbma_mono_knife", "cbma_mono_sword" ] }
+  },
+  {
+    "id": "style_niten",
+    "copy-from": "style_niten",
+    "type": "martial_art",
+    "name": { "str": "Niten Ichi-Ryu" },
+    "extend": { "weapons": [ "cbma_mono_sword" ] }
+  },
+  {
+    "id": "style_silat",
+    "copy-from": "style_silat",
+    "type": "martial_art",
+    "name": { "str": "Silat" },
+    "extend": { "weapons": [ "cbma_mono_knife" ] }
+  },
+  {
+    "id": "style_sojutsu",
+    "copy-from": "style_sojutsu",
+    "type": "martial_art",
+    "name": { "str": "Sojutsu" },
+    "extend": { "weapons": [ "cbma_mono_spear", "cbma_alloy_pile" ] }
+  }
+]

--- a/Kenan-BrightNights-Modpack/Nechronica_Redux/martialarts.json
+++ b/Kenan-BrightNights-Modpack/Nechronica_Redux/martialarts.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "style_krav_maga",
+    "copy-from": "style_krav_maga",
+    "type": "martial_art",
+    "name": { "str": "Krav Maga" },
+    "extend": { "weapons": [ "nec_fiber" ] }
+  },
+  {
+    "id": "style_swordsmanship",
+    "copy-from": "style_swordsmanship",
+    "type": "martial_art",
+    "name": { "str": "Medieval Swordsmanship" },
+    "extend": { "weapons": [ "nec_jogiri" ] }
+  },
+  {
+    "id": "style_ninjutsu",
+    "copy-from": "style_ninjutsu",
+    "type": "martial_art",
+    "name": { "str": "Ninjutsu" },
+    "extend": { "weapons": [ "nec_fiber", "nec_fine_katana" ] }
+  },
+  {
+    "id": "style_niten",
+    "copy-from": "style_niten",
+    "type": "martial_art",
+    "name": { "str": "Niten Ichi-Ryu" },
+    "extend": { "weapons": [ "nec_fine_katana" ] }
+  }
+]

--- a/Kenan-BrightNights-Modpack/Nechronica_Redux/martialarts.json
+++ b/Kenan-BrightNights-Modpack/Nechronica_Redux/martialarts.json
@@ -7,24 +7,31 @@
     "extend": { "weapons": [ "nec_fiber" ] }
   },
   {
+    "id": "style_fencing",
+    "copy-from": "style_fencing",
+    "type": "martial_art",
+    "name": { "str": "Fencing" },
+    "extend": { "weapons": [ "bio_lightsaber_fake" ] }
+  },
+  {
     "id": "style_swordsmanship",
     "copy-from": "style_swordsmanship",
     "type": "martial_art",
     "name": { "str": "Medieval Swordsmanship" },
-    "extend": { "weapons": [ "nec_jogiri" ] }
+    "extend": { "weapons": [ "nec_jogiri", "bio_lightsaber_fake" ] }
   },
   {
     "id": "style_ninjutsu",
     "copy-from": "style_ninjutsu",
     "type": "martial_art",
     "name": { "str": "Ninjutsu" },
-    "extend": { "weapons": [ "nec_fiber", "nec_fine_katana" ] }
+    "extend": { "weapons": [ "nec_fiber", "nec_fine_katana", "bio_lightsaber_fake" ] }
   },
   {
     "id": "style_niten",
     "copy-from": "style_niten",
     "type": "martial_art",
     "name": { "str": "Niten Ichi-Ryu" },
-    "extend": { "weapons": [ "nec_fine_katana" ] }
+    "extend": { "weapons": [ "nec_fine_katana", "bio_lightsaber_fake" ] }
   }
 ]

--- a/Kenan-BrightNights-Modpack/Ninja_mod/martialarts.json
+++ b/Kenan-BrightNights-Modpack/Ninja_mod/martialarts.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "style_ninjutsu",
+    "copy-from": "style_ninjutsu",
+    "type": "martial_art",
+    "name": { "str": "Ninjutsu" },
+    "extend": { "weapons": [ "ninja_katana", "ninja_kusari_gama"  ] }
+  },
+  {
+    "id": "style_niten",
+    "copy-from": "style_niten",
+    "type": "martial_art",
+    "name": { "str": "Niten Ichi-Ryu" },
+    "extend": { "weapons": [ "ninja_katana" ] }
+  }
+]

--- a/Kenan-BrightNights-Modpack/Project_Kawaii/martialarts.json
+++ b/Kenan-BrightNights-Modpack/Project_Kawaii/martialarts.json
@@ -1,0 +1,65 @@
+[
+  {
+    "id": "style_eskrima",
+    "copy-from": "style_eskrima",
+    "type": "martial_art",
+    "name": { "str": "Eskrima" },
+    "extend": { "weapons": [ "kawaii_knife_steak_twin", "kawaii_crystal_td", "kawaii_sword_steel" ] }
+  },
+  {
+    "id": "style_fencing",
+    "copy-from": "style_fencing",
+    "type": "martial_art",
+    "name": { "str": "Fencing" },
+    "extend": { "weapons": [ "kawaii_rita_and_rosa_off", "kawaii_crystal_td", "kawaii_sword_steel" ] }
+  },
+  {
+    "id": "style_krav_maga",
+    "copy-from": "style_krav_maga",
+    "type": "martial_art",
+    "name": { "str": "Krav Maga" },
+    "extend": { "weapons": [ "kawaii_crystal_td", "kawaii_knife_steak_twin", "kawaii_sword_steel" ] }
+  },
+  {
+    "id": "style_swordsmanship",
+    "copy-from": "style_swordsmanship",
+    "type": "martial_art",
+    "name": { "str": "Medieval Swordsmanship" },
+    "extend": { "weapons": [ "kawaii_shelia_off", "kawaii_rita_and_rosa", "kawaii_rita_and_rosa_off", "kawaii_crystal_td", "kawaii_sword_steel" ] }
+  },
+  {
+    "id": "style_ninjutsu",
+    "copy-from": "style_ninjutsu",
+    "type": "martial_art",
+    "name": { "str": "Ninjutsu" },
+    "extend": { "weapons": [ "kawaii_shelia_off", "kawaii_rita_and_rosa", "kawaii_rita_and_rosa_off", "kawaii_crystal_td", "kawaii_sword_steel" ] }
+  },
+  {
+    "id": "style_niten",
+    "copy-from": "style_niten",
+    "type": "martial_art",
+    "name": { "str": "Niten Ichi-Ryu" },
+    "extend": { "weapons": [ "kawaii_shelia_off", "kawaii_rita_and_rosa_off" ] }
+  },
+  {
+    "id": "style_silat",
+    "copy-from": "style_silat",
+    "type": "martial_art",
+    "name": { "str": "Silat" },
+    "extend": { "weapons": [ "kawaii_knife_steak_twin", "kawaii_crystal_td", "kawaii_sword_steel" ] }
+  },
+  {
+    "id": "style_medievalpole",
+    "copy-from": "style_medievalpole",
+    "type": "martial_art",
+    "name": { "str": "Fior Di Battaglia" },
+    "extend": { "weapons": [ "kawaii_death_scythe", "kawaii_crystal_tr", "kawaii_shelia_off" ] }
+  },
+  {
+    "id": "style_sojutsu",
+    "copy-from": "style_sojutsu",
+    "type": "martial_art",
+    "name": { "str": "Sojutsu" },
+    "extend": { "weapons": [ "kawaii_customspear_v1", "kawaii_customspear_v2", "kawaii_customspear_v3", "kawaii_crowbar_lance" ] }
+  }
+]

--- a/Kenan-BrightNights-Modpack/Vermilion_Mod/martialarts.json
+++ b/Kenan-BrightNights-Modpack/Vermilion_Mod/martialarts.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "style_ninjutsu",
+    "copy-from": "style_ninjutsu",
+    "type": "martial_art",
+    "name": { "str": "Ninjutsu" },
+    "extend": { "weapons": [ "hf_blade" ] }
+  },
+  {
+    "id": "style_niten",
+    "copy-from": "style_niten",
+    "type": "martial_art",
+    "name": { "str": "Niten Ichi-Ryu" },
+    "extend": { "weapons": [ "hf_blade" ] }
+  },
+  {
+    "id": "style_medievalpole",
+    "copy-from": "style_medievalpole",
+    "type": "martial_art",
+    "name": { "str": "Fior Di Battaglia" },
+    "extend": { "weapons": [ "absolute_reaper", "jet_hammer_off", "jet_hammer_on" ] }
+  }
+]

--- a/Kenan-BrightNights-Modpack/Vorpal_Weapons/martialarts.json
+++ b/Kenan-BrightNights-Modpack/Vorpal_Weapons/martialarts.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "style_eskrima",
+    "copy-from": "style_eskrima",
+    "type": "martial_art",
+    "name": { "str": "Eskrima" },
+    "extend": { "weapons": [ "unbio_blade_weapon_vo" ] }
+  },
+  {
+    "id": "style_fencing",
+    "copy-from": "style_fencing",
+    "type": "martial_art",
+    "name": { "str": "Fencing" },
+    "extend": { "weapons": [ "unbio_blade_weapon_vo", "laser_sword_on_vo" ] }
+  },
+  {
+    "id": "style_krav_maga",
+    "copy-from": "style_krav_maga",
+    "type": "martial_art",
+    "name": { "str": "Krav Maga" },
+    "extend": { "weapons": [ "unbio_blade_weapon_vo" ] }
+  },
+  {
+    "id": "style_swordsmanship",
+    "copy-from": "style_swordsmanship",
+    "type": "martial_art",
+    "name": { "str": "Medieval Swordsmanship" },
+    "extend": { "weapons": [ "pata_vo", "laser_sword_on_vo" ] }
+  },
+  {
+    "id": "style_ninjutsu",
+    "copy-from": "style_ninjutsu",
+    "type": "martial_art",
+    "name": { "str": "Ninjutsu" },
+    "extend": { "weapons": [ "unbio_blade_weapon_vo", "pata_vo", "laser_sword_on_vo" ] }
+  },
+  {
+    "id": "style_niten",
+    "copy-from": "style_niten",
+    "type": "martial_art",
+    "name": { "str": "Niten Ichi-Ryu" },
+    "extend": { "weapons": [ "laser_sword_on_vo" ] }
+  },
+  {
+    "id": "style_silat",
+    "copy-from": "style_silat",
+    "type": "martial_art",
+    "name": { "str": "Silat" },
+    "extend": { "weapons": [ "unbio_blade_weapon_vo" ] }
+  },
+  {
+    "id": "style_medievalpole",
+    "copy-from": "style_medievalpole",
+    "type": "martial_art",
+    "name": { "str": "Fior Di Battaglia" },
+    "extend": { "weapons": [ "battlehook_vo" ] }
+  }
+]

--- a/Kenan-BrightNights-Modpack/ZSFixed_CDDAXP/martialarts.json
+++ b/Kenan-BrightNights-Modpack/ZSFixed_CDDAXP/martialarts.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "style_eskrima",
+    "copy-from": "style_eskrima",
+    "type": "martial_art",
+    "name": { "str": "Eskrima" },
+    "extend": { "weapons": [ "cddaxp_cknife", "cddaxp_cmachete", "cddaxp_ckukri" ] }
+  },
+  {
+    "id": "style_fencing",
+    "copy-from": "style_fencing",
+    "type": "martial_art",
+    "name": { "str": "Fencing" },
+    "extend": { "weapons": [ "cddaxp_crapier", "cddaxp_cbroadsword" ] }
+  },
+  {
+    "id": "style_krav_maga",
+    "copy-from": "style_krav_maga",
+    "type": "martial_art",
+    "name": { "str": "Krav Maga" },
+    "extend": { "weapons": [ "cddaxp_cknife" ] }
+  },
+  {
+    "id": "style_swordsmanship",
+    "copy-from": "style_swordsmanship",
+    "type": "martial_art",
+    "name": { "str": "Medieval Swordsmanship" },
+    "extend": { "weapons": [ "cddaxp_cbroadsword", "cddaxp_czweihander" ] }
+  },
+  {
+    "id": "style_ninjutsu",
+    "copy-from": "style_ninjutsu",
+    "type": "martial_art",
+    "name": { "str": "Ninjutsu" },
+    "extend": { "weapons": [ "cddaxp_sai", "cddaxp_cknife", "cddaxp_cmachete", "cddaxp_ckukri", "cddaxp_ckatana", "cddaxp_cwakizashi", "cddaxp_cnodachi", "cddaxp_dkusarigama", "cddaxp_ckusarigama"  ] }
+  },
+  {
+    "id": "style_niten",
+    "copy-from": "style_niten",
+    "type": "martial_art",
+    "name": { "str": "Niten Ichi-Ryu" },
+    "extend": { "weapons": [ "cddaxp_ckatana", "cddaxp_cwakizashi", "cddaxp_cnodachi" ] }
+  },
+  {
+    "id": "style_silat",
+    "copy-from": "style_silat",
+    "type": "martial_art",
+    "name": { "str": "Silat" },
+    "extend": { "weapons": [ "cddaxp_cknife", "cddaxp_cmachete" ] }
+  },
+  {
+    "id": "style_sojutsu",
+    "copy-from": "style_sojutsu",
+    "type": "martial_art",
+    "name": { "str": "Sojutsu" },
+    "extend": { "weapons": [ "cddaxp_bo" ] }
+  }
+]

--- a/Kenan-BrightNights-Modpack/pixels_fuckery/martialarts.json
+++ b/Kenan-BrightNights-Modpack/pixels_fuckery/martialarts.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "style_sojutsu",
+    "copy-from": "style_sojutsu",
+    "type": "martial_art",
+    "name": { "str": "Sojutsu" },
+    "extend": { "weapons": [ "aluminumbwirebat", "aluminumbattletorch", "aluminumbattletorch_lit", "aluminumbattletorch_done", "aluminumchainbat", "chainbat" ] }
+  }
+]


### PR DESCRIPTION
Got annoyed that Project Kwaii had a sword-and-shield that couldn't be used with Medieval Swordsmanship, so I went ahead and did some basic martial arts JSON for several mods that otherwise lacked them (a few, Vermillion and Nechronica, had files for their own built-in modded martial arts but not for 'core' martial arts). Most of it is pretty self-explanatory, though I got a bit liberal in terms of the Project Kawaii stuff as some of it doesn't describe what the 'blade form' of a given weapon is. Also, Pixel's Fuckery applied the new baseball bat weapons to Sojutsu because, for some insane reason, Aftershock assigned the titanium bat to Sojutsu. Weird, but I didn't make the mod.